### PR TITLE
Refresh from Eureka xcode9-swift3_2 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,7 +950,6 @@ Let us know about it, we would be glad to mention it here. :)
 Specify Eureka into your project's `Podfile`:
 
 ```ruby
-source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '9.0'
 use_frameworks!
 

--- a/Source/Core/Helpers.swift
+++ b/Source/Core/Helpers.swift
@@ -79,6 +79,12 @@ extension NSExpression {
     }
 }
 
+// This is a workaround for warnings in the Swift 3.2 compiler that are triggered when a generic type
+// is explicitly constrained while already implicitly constrained.
+// For instance `T: Hashable where Cell.Value == Set<T>` triggers a warning on Swift 3.2 because Set already
+// has the constraint `T: Hashable`.
+// However Swift 3.1 doesn't infer this constraint, so we need to constraint explicitly. To do this,
+// we define a `_ImplicitlyHashable` type which is Any on 3.2+ and Hashable for earlier versions.
 #if swift(>=3.2)
 public typealias _ImplicitlyHashable = Any
 #else

--- a/Source/Core/Helpers.swift
+++ b/Source/Core/Helpers.swift
@@ -36,6 +36,7 @@ extension UIView {
         }
         return nil
     }
+    
 
     public func formCell() -> BaseCell? {
         if self is UITableViewCell {
@@ -77,3 +78,9 @@ extension NSExpression {
         }
     }
 }
+
+#if swift(>=3.2)
+public typealias _ImplicitlyHashable = Any
+#else
+public typealias _ImplicitlyHashable = Hashable
+#endif

--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -279,8 +279,8 @@ extension Section : RangeReplaceableCollection {
             }
         }
 
-        kvoWrapper.rows.replaceObjects(in: NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound),
-                                       withObjectsFrom: newElements.map { $0 })
+        let range = NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound)
+        kvoWrapper.rows.replaceObjects(in: range, withObjectsFrom: newElements.map { $0 })
 
         kvoWrapper._allRows.insert(contentsOf: newElements, at: indexForInsertion(at: subrange.lowerBound))
         for row in newElements {
@@ -296,8 +296,8 @@ extension Section : RangeReplaceableCollection {
             }
         }
         
-        kvoWrapper.rows.replaceObjects(in: NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound),
-                                       withObjectsFrom: newElements.map { $0 })
+        let range = NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound)
+        kvoWrapper.rows.replaceObjects(in: range, withObjectsFrom: newElements.map { $0 })
         
         kvoWrapper._allRows.insert(contentsOf: newElements, at: indexForInsertion(at: subrange.lowerBound))
         for row in newElements {

--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -53,7 +53,8 @@ extension Section {
 
     internal class KVOWrapper: NSObject {
 
-        dynamic private var _rows = NSMutableArray()
+        @objc dynamic private var _rows = NSMutableArray()
+        @objc dynamic private var _deletedRows = NSMutableArray()
         var rows: NSMutableArray {
             return mutableArrayValue(forKey: "_rows")
         }
@@ -71,6 +72,7 @@ extension Section {
             removeObserver(self, forKeyPath: "_rows")
             _rows.removeAllObjects()
             _allRows.removeAll()
+            _deletedRows.removeAllObjects()
         }
 
         public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
@@ -90,11 +92,13 @@ extension Section {
                     delegateValue?.rowsHaveBeenAdded(newRows, at: indexSet.map { IndexPath(row: $0, section: _index ) })
                 }
             case NSKeyValueChange.removal.rawValue:
+                _deletedRows.addObjects(from: oldRows)
                 let indexSet = change![NSKeyValueChangeKey.indexesKey] as! IndexSet
                 section?.rowsHaveBeenRemoved(oldRows, at: indexSet)
                 if let _index = section?.index {
                     delegateValue?.rowsHaveBeenRemoved(oldRows, at: indexSet.map { IndexPath(row: $0, section: _index ) })
                 }
+                _deletedRows.removeAllObjects()
             case NSKeyValueChange.replacement.rawValue:
                 let indexSet = change![NSKeyValueChangeKey.indexesKey] as! IndexSet
                 section?.rowsHaveBeenReplaced(oldRows: oldRows, newRows: newRows, at: indexSet)
@@ -104,6 +108,10 @@ extension Section {
             default:
                 assertionFailure()
             }
+        }
+        
+        public func deletedRows() -> [BaseRow] {
+            return _deletedRows as! [BaseRow]
         }
     }
 
@@ -208,7 +216,12 @@ extension Section : MutableCollection, BidirectionalCollection {
     public subscript (position: Int) -> BaseRow {
         get {
             if position >= kvoWrapper.rows.count {
-                assertionFailure("Section: Index out of bounds")
+                let offsetPosition = position-kvoWrapper.rows.count
+                let deletedRows = kvoWrapper.deletedRows()
+                if offsetPosition >= deletedRows.count {
+                    assertionFailure("Section: Index out of bounds")
+                }
+                return deletedRows[offsetPosition]
             }
             return kvoWrapper.rows[position] as! BaseRow
         }

--- a/Source/Rows/MultipleSelectorRow.swift
+++ b/Source/Rows/MultipleSelectorRow.swift
@@ -31,7 +31,7 @@ open class _MultipleSelectorRow<T: _ImplicitlyHashable, Cell>: GenericMultipleSe
 }
 
 /// A selector row where the user can pick several options from a pushed view controller
-public final class MultipleSelectorRow<T: _ImplicitlyHashable> : _MultipleSelectorRow<T, PushSelectorCell<Set<T>>>, RowType {
+public final class MultipleSelectorRow<T: Hashable> : _MultipleSelectorRow<T, PushSelectorCell<Set<T>>>, RowType {
     public required init(tag: String?) {
         super.init(tag: tag)
     }

--- a/Source/Rows/MultipleSelectorRow.swift
+++ b/Source/Rows/MultipleSelectorRow.swift
@@ -24,14 +24,14 @@
 
 import Foundation
 
-open class _MultipleSelectorRow<T, Cell: CellType>: GenericMultipleSelectorRow<T, Cell> where Cell: BaseCell, Cell.Value == Set<T> {
+open class _MultipleSelectorRow<T: _ImplicitlyHashable, Cell>: GenericMultipleSelectorRow<T, Cell, MultipleSelectorViewController<T>> where Cell: BaseCell, Cell: CellType, Cell.Value == Set<T> {
     public required init(tag: String?) {
         super.init(tag: tag)
     }
 }
 
 /// A selector row where the user can pick several options from a pushed view controller
-public final class MultipleSelectorRow<T: Hashable> : _MultipleSelectorRow<T, PushSelectorCell<Set<T>>>, RowType {
+public final class MultipleSelectorRow<T: _ImplicitlyHashable> : _MultipleSelectorRow<T, PushSelectorCell<Set<T>>>, RowType {
     public required init(tag: String?) {
         super.init(tag: tag)
     }


### PR DESCRIPTION
We forked Eureka to fix a bug in removing rows. Since then Swift has changed and Eureka has made changes to update Eureka for Xcode 9 and Swift 3.2. This PR starts with the Eureka branch for that and redoes the changes @phomelvig originally did.

This compiles in Caliber H2O with no errors for Xcode 9 and Swift 3.2. And I've verified the original bug is still fixed by this branch.