### PR TITLE
move over change from original Eureka repo to fix a compiler crash

### DIFF
--- a/Source/Core/SelectableSection.swift
+++ b/Source/Core/SelectableSection.swift
@@ -62,7 +62,7 @@ public protocol SelectableSectionType: Collection {
     func selectedRows() -> [SelectableRow]
 }
 
-extension SelectableSectionType where Self: Section {
+extension SelectableSectionType where Element == BaseRow, Self: AnyObject {
     /**
      Returns the selected row of this section. Should be used if selectionType is SingleSelection
      */


### PR DESCRIPTION
Move this fix:

https://github.com/xmartlabs/Eureka/pull/2061

into our repo.